### PR TITLE
fix(): icon declarations now recognize react and vue syntax

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "ionicons",
 	"displayName": "ionicons",
 	"description": "Display ionic icons in the gutter of vscode",
-	"version": "0.0.6",
+	"version": "0.0.7",
 	"icon": "resources/icon.png",
 	"repository": "https://github.com/realappie/ionicons-vscode",
 	"author": {
@@ -18,7 +18,10 @@
 		"Other"
 	],
 	"activationEvents": [
-		"onLanguage:html"
+		"onLanguage:html",
+		"onLanguage:vue",
+		"onLanguage:javascriptreact",
+		"onLanguage:typescriptreact"
 	],
 	"main": "./out/extension.js",
 	"contributes": {

--- a/package.json
+++ b/package.json
@@ -58,7 +58,8 @@
 		"compile": "tsc -p ./",
 		"watch": "tsc -watch -p ./",
 		"pretest": "npm run compile",
-		"test": "node ./out/test/runTest.js"
+		"test": "node ./out/test/runTest.js",
+		"package": "npm run compile && vsce package -o out/ionicons.vsix"
 	},
 	"devDependencies": {
 		"@types/glob": "^7.1.1",

--- a/src/ion-icons-decorations.ts
+++ b/src/ion-icons-decorations.ts
@@ -51,20 +51,24 @@ export class IonIconsDecorations implements vscode.Disposable {
     }
 
     const text = vscode.window.activeTextEditor?.document.getText();
-
     const matches = Array.from(
       text!.matchAll(
-        /(?!<ion-icon .*)(name)=["']?((?:.(?!["']?\s+(?:\S+)=|[>"']))+.)["']?/g
+        /(ion-icon|IonIcon) (.*)(name|icon)=["|'|{]([\w- ]*)/g
       )
     );
+
     // TODO figure out a cleaner way to find ion-icons elements
     // see https://github.com/microsoft/vscode/issues/59921
     //
     matches.forEach((match) => {
-      const [, , iconName] = match;
+
+      // The last match should be the icon name
+      const rawIconName = match[match.length - 1];
+
+      // Convert camel case (i.e. "alarmOutline") to kebab case (i.e. "alarm-outline")
+      const iconName = rawIconName.replace(/([a-z0-9]|(?=[A-Z]))([A-Z])/g, '$1-$2').toLowerCase();
 
       const lightIconFileName = `${iconName}.svg`;
-
       const darkIconFileName = `${iconName}-dark-mode.svg`;
 
       const lightModeIconPath = createFilePath({
@@ -145,7 +149,7 @@ export class IonIconsDecorations implements vscode.Disposable {
 
   /** we dont want to be handling all files */
   isAnalyzable(textDocument: vscode.TextDocument): boolean {
-    const analyzableLanguages = ['html'];
+    const analyzableLanguages = ['html', 'vue', 'javascriptreact', 'typescriptreact'];
     return analyzableLanguages.includes(textDocument.languageId);
   }
 


### PR DESCRIPTION
This PR adds support to show icons in the sidebar when using Ionic React and Ionic Vue. This PR does not add support for autocomplete (Autocomplete is not working for me even in an Angular app, so I was not able to work on that).

I also added a new script to `package.json` that makes it easier to test your extension locally. Let me know if you want me to remove it.